### PR TITLE
Add mastodon helm chart as a submodule to the new chart repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Configure Git
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "charts/mastodon"]
+	path = charts/mastodon
+	url = git@github.com:mastodon/chart.git


### PR DESCRIPTION
Based on the discussion in https://github.com/mastodon/chart/issues/129, I wanted to propose a temporary fix that would fix some of the pain points in how the helm charts are pulled and just provide them as is under the current one.

This isn't meant to close #129 but rather provide a stop-gap option prior to a broader re-write of the chart. Tested locally by trying to pull published chart.