### PR TITLE
INF-246: Add additional settings to pgbouncer

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/charts/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -23,7 +23,7 @@ listen_port = 6432
 ; unix_socket_dir = var/run/postgresql
 ;unix_socket_mode = 0777
 ;unix_socket_group =
-;client_tls_sslmode = disable
+client_tls_sslmode = {{ .Values.settings.tls.clientMode }}
 ;client_tls_ca_file = <system default>
 ;client_tls_key_file =
 ;client_tls_cert_file =
@@ -31,7 +31,7 @@ listen_port = 6432
 ;client_tls_protocols = all
 ;client_tls_dheparams = auto
 ;client_tls_ecdhcurve = auto
-;server_tls_sslmode = disable
+server_tls_sslmode = {{ .Values.settings.tls.serverMode }}
 ;server_tls_ca_file = <system default>
 ;server_tls_key_file =
 ;server_tls_cert_file =
@@ -41,9 +41,12 @@ listen_port = 6432
 
 ;;; Authentication settings
 
-auth_type = md5
-;auth_file = /8.0/main/global/pg_auth
+auth_type = {{ .Values.settings.authType }}
+{{- if and .Values.authFile.secretRef.name .Values.authFile.secretRef.key }}
 auth_file = /etc/pgbouncer/userlist.txt
+{{- else }}
+;auth_file =
+{{- end }}
 ;auth_hba_file =
 
 {{ .Values.settings.auth_query }}

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -50,14 +50,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: userssecret
-              mountPath: /etc/pgbouncer/userlist.txt
-              subPath: {{ .Values.usersSecretRef.key }}
-              readOnly: true
             - name: config
               mountPath: /etc/pgbouncer/pgbouncer.ini
               subPath: pgbouncer.ini
               readOnly: true
+            {{- if and .Values.authFile.secretRef.name .Values.authFile.secretRef.key }}
+            - name: auth-file
+              mountPath: /etc/pgbouncer/userlist.txt
+              subPath: {{ .Values.authFile.secretRef.key }}
+              readOnly: true
+            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -99,15 +101,17 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
-        - name: userssecret
-          secret:
-            secretName: {{ .Values.usersSecretRef.name }}
-            items:
-              - key: {{ .Values.usersSecretRef.key }}
-                path: userlist.txt
         - name: config
           configMap:
             name: {{ template "pgbouncer.fullname" . }}-config
             items:
               - key: pgbouncer.ini
                 path: pgbouncer.ini
+        {{- if and .Values.authFile.secretRef.name .Values.authFile.secretRef.key }}
+        - name: auth-file
+          secret:
+            secretName: {{ .Values.authFile.secretRef.name }}
+            items:
+              - key: {{ .Values.authFile.secretRef.key }}
+                path: userlist.txt
+        {{- end }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -21,10 +21,15 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+# List of users written in key=value lines like:
+#    user1: settings
+users: {}
+
 # The secret containing the userlist.txt to deploy
-usersSecretRef:
-  name: pgbouncer-conf-users
-  key: userlist.txt
+authFile:
+  secretRef:
+    name:
+    key:
 
 databases:
   # name:
@@ -34,8 +39,13 @@ databases:
   #   dbname:
 
 settings:
+  authType: scram-sha-256
   adminUsers: []
-  statsUsers: [pgbouncer_exporter]
+  statsUsers: []
+
+  tls:
+    clientMode: disable
+    serverMode: require
 
   poolMode: transaction
   serverResetQuery: DISCARD ALL
@@ -67,8 +77,11 @@ settings:
 # but will wait until all transactions end, or this amount of time
 terminationGracePeriodSeconds: 120
 
+# Sidecar configuration for prometheus exporter.
+# This sidecar needs an additional user "pgbouncer_exporter" to be configured in
+# the auth_file if enabled.
 prometheusExporter:
-  enabled: true
+  enabled: false
   statsPgUser: pgbouncer_exporter
   statsPgPasswordSecretRef:
     name: pgbouncer-exporter-password


### PR DESCRIPTION
- Added ability to set client- and server-side `sslmode`
- Renamed `usersSecretRef` to `authFile.secretRef` to make it easier to understand / associate it with pgbouncer's config naming
- `auth_file` is not mounted if none is given
- `users` field is defined & commented in values file for extra clarity
- Changed some defaults
- Added some additional comments for clarity

Tested this against db-03 and db-04, works well.