### PR TITLE
Add dragonfly chart

### DIFF
--- a/charts/dragonfly/.helmignore
+++ b/charts/dragonfly/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: dragonfly
+description: Dragonfly deployments for a Mastodon app.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/dragonfly/templates/_helpers.tpl
+++ b/charts/dragonfly/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dragonfly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dragonfly.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dragonfly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dragonfly.labels" -}}
+helm.sh/chart: {{ include "dragonfly.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/name: dragonfly
+app.kubernetes.io/instance: {{ include "dragonfly.fullname" . }}
+app.kubernetes.io/part-of: dragonfly-operator
+app.kubernetes.io/created-by: dragonfly-operator
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/dragonfly/templates/dragonfly-app.yml
+++ b/charts/dragonfly/templates/dragonfly-app.yml
@@ -1,0 +1,34 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  labels:
+  name: {{ include "dragonfly.fullname" . }}-app
+spec:
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+    {{- with .Values.nodeSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  replicas: 1
+  args:
+    - "--dbfilename=dragonflydbSnapshot"
+  snapshot:
+    cron: "{{ .Values.snapshot.cron }}"
+    persistentVolumeClaimSpec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.snapshot.storage }}
+  {{- if .Values.resources }}
+  resources:
+    {{- with .Values.resources }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/dragonfly/templates/dragonfly-cache.yml
+++ b/charts/dragonfly/templates/dragonfly-cache.yml
@@ -1,0 +1,34 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  labels:
+  name: {{ include "dragonfly.fullname" . }}-cache
+spec:
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+    {{- with .Values.nodeSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  replicas: 1
+  args:
+    - "--dbfilename=dragonflydbSnapshot"
+  snapshot:
+    cron: "{{ .Values.snapshot.cron }}"
+    persistentVolumeClaimSpec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.snapshot.storage }}
+  {{- if .Values.resources }}
+  resources:
+    {{- with .Values.resources }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/dragonfly/templates/dragonfly-sidekiq.yml
+++ b/charts/dragonfly/templates/dragonfly-sidekiq.yml
@@ -1,0 +1,34 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  labels:
+  name: {{ include "dragonfly.fullname" . }}-sidekiq
+spec:
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+    {{- with .Values.nodeSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  replicas: 1
+  args:
+    - "--dbfilename=dragonflydbSnapshot"
+  snapshot:
+    cron: "{{ .Values.snapshot.cron }}"
+    persistentVolumeClaimSpec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.snapshot.storage }}
+  {{- if .Values.resources }}
+  resources:
+    {{- with .Values.resources }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -1,0 +1,37 @@
+# Default values for dragonfly.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Number of replicas for each dragonfly cluster.
+replicas: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# Name to give the dragonfly instances
+name: dragonfly
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Snapshot configuration
+snapshot:
+  cron: "*/5 * * * *"      # Every 5 minutes
+  storage: 20Gi
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}


### PR DESCRIPTION
Similar to the cloudnative chart, makes it easier to just define what we need while keeping the configuration as DRY as possible.