### PR TITLE
feature: make rclone S3 provider configurable for MinIO support

### DIFF
--- a/charts/mastodon/templates/job-assets-copy.yaml
+++ b/charts/mastodon/templates/job-assets-copy.yaml
@@ -53,7 +53,7 @@ spec:
           - name: RCLONE_CONFIG_REMOTE_TYPE
             value: s3
           - name: RCLONE_CONFIG_REMOTE_PROVIDER
-            value: AWS
+            value:  {{ .Values.mastodon.hooks.s3Upload.rclone.configRemoteProvider }}
           - name: RCLONE_CONFIG_REMOTE_ENDPOINT
             value: {{ required "Please specify an endpoint for S3 asset uploads" .Values.mastodon.hooks.s3Upload.endpoint }}
           - name: RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID

--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -197,6 +197,8 @@ mastodon:
 
       # Configuration for the rclone container that will preform the upload.
       rclone:
+        # You can use Minio
+        configRemoteProvider: S3
 
         # Any additional environment variables to pass to rclone.
         env: {}


### PR DESCRIPTION
Hardcoded RCLONE_CONFIG_REMOTE_PROVIDER variable in the job-assets-copy prevented the use of MinIO. I moved it into a separate configuration parameter s3Upload.rclone.configRemoteProvider, where either AWS or MinIO can be specified.