### PR TITLE
Better customization for HTTPRoutes

### DIFF
--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     url: https://joinmastodon.org
 icon: https://avatars.githubusercontent.com/u/24979032
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "v4.5.9"

--- a/charts/mastodon/templates/httproute-streaming.yaml
+++ b/charts/mastodon/templates/httproute-streaming.yaml
@@ -16,18 +16,24 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+    {{- coalesce .Values.httproute.streamingParentRefs .Values.httproute.parentRefs | toYaml | nindent 4 }}
   hostnames:
-    {{- toYaml .Values.httproute.streamingHostnames | nindent 4 }}
+    {{- coalesce .Values.httproute.streamingHostnames .Values.httproute.hostnames | toYaml | nindent 4 }}
   rules:
+    {{- range .Values.httproute.streamingRules }}
+    {{- with .matches }}
     - matches:
-      - path:
-          type: PathPrefix
-          value: /api/v1/streaming
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
       backendRefs:
         - group: ''
           kind: Service
           name: {{ $fullName }}-streaming
           port: {{ $streamingPort }}
           weight: 1
+    {{- end }}
 {{- end }}

--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -815,6 +815,13 @@ httproute:
   hostnames:
     - mastodon.local
 
+  # Refernce(s) to the Gateway(s) for streaming, if different than the instance
+  # gateway.
+  streamingParentRefs: []
+  #  - name: example-streaming-gateway
+  #    namespace: example-streaming-gateway-namespace
+  #    sectionName: websecure
+
   # Streaming hostnames, if different than the instance hostname.
   streamingHostnames: []
   #  - streaming.mastodon.local
@@ -825,6 +832,14 @@ httproute:
       - path:
           type: PathPrefix
           value: /
+
+  # Routing rules for the streaming API.
+  streamingRules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /api/v1/streaming
+
 
 # Configuration for PostgreSQL.
 postgresql:


### PR DESCRIPTION
Added the ability to specify both custom `parentRefs` and `rules` for separate streaming `HTTPRoute`.