### PR TITLE
fix: inject Elasticsearch credentials into the deploy-search job

### DIFF
--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     url: https://joinmastodon.org
 icon: https://avatars.githubusercontent.com/u/24979032
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "v4.7.1"

--- a/charts/mastodon/templates/job-deploy-search.yaml
+++ b/charts/mastodon/templates/job-deploy-search.yaml
@@ -64,6 +64,7 @@ spec:
             {{- include "mastodon.secrets.secret" . | nindent 12 }}
             {{- include "mastodon.secrets.database" . | nindent 12 }}
             {{- include "mastodon.secrets.redis" . | nindent 12 }}
+            {{- include "mastodon.secrets.elasticsearch" . | nindent 12 }}
             {{- include "mastodon.secrets.ldap" . | nindent 12 }}
           {{- with .Values.mastodon.hooks.deploySearch.resources }}
           resources:


### PR DESCRIPTION
## What

The `deploy-search` hook Job (`templates/job-deploy-search.yaml`) is missing the `mastodon.secrets.elasticsearch` env include, so `ES_USER` / `ES_PASS` are never passed to the `tootctl search deploy` container.

## Why

When Elasticsearch requires authentication (e.g. an ECK-managed cluster with a file realm, or any cluster with security enabled), the job fails:

> [401] {"error":{"root_cause":[{"type":"security_exception", "reason":"missing authentication credentials for REST request [/chewy_specifications/_alias]"...}

The `web` and `sidekiq` deployments already include `mastodon.secrets.elasticsearch`; the deploy-search job was simply overlooked.
This affects current releases including 1.0.3.

## Change

- Add `{{- include "mastodon.secrets.elasticsearch" . | nindent 12 }}` to the job env (placed alongside the other secret includes).

## Testing

`helm template` with `mastodon.hooks.deploySearch.enabled=true`, `elasticsearch.enabled=true` and an `elasticsearch.existingSecret` now renders `ES_USER` / `ES_PASS` (`secretKeyRef`) in the deploy-search Job, matching the web/sidekiq deployments.