### PR TITLE
Fix invalid volumeMounts rendering in sidekiq and web

### DIFF
--- a/charts/mastodon/ci/volume-mounts-values.yaml
+++ b/charts/mastodon/ci/volume-mounts-values.yaml
@@ -1,0 +1,37 @@
+mastodon:
+  localDomain: mydomain.social
+  limitedFederationMode: true
+  secrets:
+    secretKeyBase: some-secret-key-base
+    vapidPrivateKey: some-vapid-private-key
+    vapidPublicKey: some-vapid-public-key
+    arePrimaryKey: some-are-primary-key
+    areDeterministicKey: some-are-deterministic-key
+    areKeyDerivationSalt: some-are-key-derivation-salt
+  s3:
+    hostname: https://s3.us-east-1.amazonaws.com/
+    endpoint: s3.us-east-1.amazonaws.com
+    region: us-east-1
+    bucket: mastodon-media
+    accessKeyId: some-access-key-id
+    secretAccessKey: some-secret-access-key
+  smtp:
+    server: smtp.postmarkapp.com
+    username: username
+    password: password
+httproute:
+  hostnames:
+    - mydomain.social
+postgresql:
+  hostname: postgres-rw
+  username: mastodon
+  password: password
+redis:
+  hostname: redis-redis-ha
+  password: password
+volumes:
+  - name: tmp
+    emptyDir: {}
+volumeMounts:
+  - name: tmp
+    mountPath: /opt/mastodon/tmp

--- a/charts/mastodon/templates/_deployment.tpl
+++ b/charts/mastodon/templates/_deployment.tpl
@@ -64,15 +64,13 @@ envFrom:
 Standard volumes that will be mounted for most pods.
 */}}
 {{- define "mastodon.volumes" -}}
-{{- if .Values.volumeMounts }}
 {{- with .Values.volumes }}
-  {{- toYaml . | nindent 8 }}
+{{- toYaml . }}
 {{- end }}
 {{- if .Values.elasticsearch.caSecret.name }}
-  - name: elasticsearch-ca
-    secret:
-      secretName: {{ .Values.elasticsearch.caSecret.name }}
-{{- end }}
+- name: elasticsearch-ca
+  secret:
+    secretName: {{ .Values.elasticsearch.caSecret.name }}
 {{- end }}
 {{- end }}
 
@@ -80,17 +78,14 @@ Standard volumes that will be mounted for most pods.
 Standard volumeMounts that will be configured for most containers.
 */}}
 {{- define "mastodon.volumeMounts" -}}
-{{- if .Values.volumeMounts }}
-volumeMounts:
 {{- with .Values.volumeMounts }}
-  {{- toYaml . | nindent 12 }}
+{{- toYaml . }}
 {{- end }}
 {{- if .Values.elasticsearch.caSecret.name }}
-  - name: elasticsearch-ca
-    mountPath: {{ .Values.elasticsearch.caSecret.mountPath }}
-    subPath: {{ .Values.elasticsearch.caSecret.key }}
-    readOnly: true
-{{- end }}
+- name: elasticsearch-ca
+  mountPath: {{ .Values.elasticsearch.caSecret.mountPath }}
+  subPath: {{ .Values.elasticsearch.caSecret.key }}
+  readOnly: true
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fixes: #65  

## Problem

Setting `volumeMounts` / `volumes` in values breaks the `web` and `sidekiq` Deployments. The `mastodon.volumeMounts` and `mastodon.volumes` helpers emit their own key and indentation , but the deployment templates already print the key... so we end up with a duplicate nested `volumeMounts:` and the install fails with `expected list, got map`.

This is the same bug as #23 (fixed for `streaming` in #24) but reintroduced for web/sidekiq by the helper refactor in #46

## Fix

The helpers now only emit list items (same pattern as the `mastodon.pvc.*` helpers), so the key is written in exactly one place

And  as a side effect, this also restores the elasticsearch CA secret mount when `elasticsearch.caSecret.name` is set without user `volumeMounts`