### PR TITLE
Add securityContext to prometheus-exporter sidecar

### DIFF
--- a/charts/mastodon/templates/deployment-web.yaml
+++ b/charts/mastodon/templates/deployment-web.yaml
@@ -145,6 +145,10 @@ spec:
         {{- if .Values.mastodon.metrics.prometheus.enabled }}
         - name: prometheus-exporter
           image: "{{ coalesce .Values.mastodon.web.image.repository .Values.image.repository }}:{{ coalesce .Values.mastodon.web.image.tag .Values.image.tag .Chart.AppVersion }}"
+          {{- with coalesce .Values.mastodon.web.securityContext .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - ./bin/prometheus_exporter
           args:


### PR DESCRIPTION
Fixes #67 

The `prometheus-exporter` sidecar in the web Deployment now applies the same `securityContext` as the main container instead of None:

```yaml
{{- with coalesce .Values.mastodon.web.securityContext .Values.securityContext }}
securityContext:
  {{- toYaml . | nindent 12 }}
{{- end }}
```

No behavior change when no `securityContext` is set: the block is simply omitted, so rendered output stays identical for existing users