### PR TITLE
'env' values should conform to kube EnvVar spec for more flexibility

### DIFF
--- a/charts/fediscoverer/Chart.yaml
+++ b/charts/fediscoverer/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
     url: https://joinmastodon.org
 icon: https://avatars.githubusercontent.com/u/24979032
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "v0.1.0"

--- a/charts/fediscoverer/templates/deployment-jobs.yaml
+++ b/charts/fediscoverer/templates/deployment-jobs.yaml
@@ -70,13 +70,11 @@ spec:
             - name: OTEL_SERVICE_NAME_SEPARATOR
               value: "{{ coalesce .Values.jobs.otel.nameSeparator .Values.otel.nameSeparator }}"
             {{- end }}
-            {{- range $key, $value := .Values.jobs.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- with .Values.jobs.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/fediscoverer/templates/deployment-web.yaml
+++ b/charts/fediscoverer/templates/deployment-web.yaml
@@ -77,13 +77,11 @@ spec:
             - name: OTEL_SERVICE_NAME_SEPARATOR
               value: "{{ coalesce .Values.web.otel.nameSeparator .Values.otel.nameSeparator }}"
             {{- end }}
-            {{- range $key, $value := .Values.web.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- with .Values.web.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/fediscoverer/values.yaml
+++ b/charts/fediscoverer/values.yaml
@@ -71,7 +71,7 @@ web:
 
   # Additional environment variables to set for all web pods.
   # Applied in additional to global env values.
-  env: {}
+  env: []
 
   # Open Telemetry configuration for web pods.
   # Overrides global settings.
@@ -101,7 +101,7 @@ jobs:
 
   # Additional environment variables to set for all job pods.
   # Applied in additional to global env values.
-  env: {}
+  env: []
 
   # Open Telemetry configuration for web pods.
   # Overrides global settings.
@@ -112,7 +112,7 @@ jobs:
     nameSeparator: ""
 
 # Additional environment variables to set for all pods.
-env: {}
+env: []
 
 # Whether to enable the prometheus exporter for monitoring
 metrics:


### PR DESCRIPTION
`.Values.env` should follow the `EnvVar` kubernetes spec instead of just being key/values. This would allow for things like:
```yaml
env:
  - name: MY_ENV_VAR
    valueFrom:
      secretRef:
        name: my-secret
        key: my-secret-key
```

Or, the reason that I need this functionality, to have the pod be aware of its host IP to use datadog's OTEL exporter:
```yaml
env:
  - name: HOST_IP
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```

Part of INF-459