### PR TITLE
User-defined environment variables appear first in the manifest

### DIFF
--- a/charts/fediscoverer/Chart.yaml
+++ b/charts/fediscoverer/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
     url: https://joinmastodon.org
 icon: https://avatars.githubusercontent.com/u/24979032
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "v0.1.0"

--- a/charts/fediscoverer/templates/deployment-jobs.yaml
+++ b/charts/fediscoverer/templates/deployment-jobs.yaml
@@ -44,6 +44,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- with .Values.jobs.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: DOMAIN
               value: {{ .Values.config.domain }}
             - name: SECRET_KEY_BASE
@@ -69,12 +75,6 @@ spec:
               value: {{ coalesce .Values.jobs.otel.namePrefix .Values.otel.namePrefix }}
             - name: OTEL_SERVICE_NAME_SEPARATOR
               value: "{{ coalesce .Values.jobs.otel.nameSeparator .Values.otel.nameSeparator }}"
-            {{- end }}
-            {{- with .Values.jobs.env }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.env }}
-            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/fediscoverer/templates/deployment-web.yaml
+++ b/charts/fediscoverer/templates/deployment-web.yaml
@@ -43,6 +43,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- with .Values.web.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: DOMAIN
               value: {{ .Values.config.domain }}
             - name: SECRET_KEY_BASE
@@ -76,12 +82,6 @@ spec:
               value: {{ coalesce .Values.web.otel.namePrefix .Values.otel.namePrefix }}
             - name: OTEL_SERVICE_NAME_SEPARATOR
               value: "{{ coalesce .Values.web.otel.nameSeparator .Values.otel.nameSeparator }}"
-            {{- end }}
-            {{- with .Values.web.env }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.env }}
-            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
This is important for defining dependent ENV variables in kubernetes, as they must come first.

Part of INF-459